### PR TITLE
Remove DemoBadge

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { DemoBadge } from '@/components/DemoBadge';
 import arcjet, { detectBot, request } from '@/libs/Arcjet';
 import { Env } from '@/libs/Env';
 import { routing } from '@/libs/i18nNavigation';
@@ -93,8 +92,6 @@ export default async function RootLayout(props: {
           messages={messages}
         >
           {props.children}
-
-          <DemoBadge />
         </NextIntlClientProvider>
       </body>
     </html>


### PR DESCRIPTION
In the first version we didn't pay attention to the Boilerplate "banner" on the bottom of the website:

<img width="198" alt="Screenshot 2025-02-02 at 12 02 09" src="https://github.com/user-attachments/assets/8ba14bc2-9615-4c72-b4c5-78a3eb5177f4" />

In this MR, we simply remove it.
